### PR TITLE
When there is an XML attribute called "text" it conflicts with the "text" string used for the tag body content

### DIFF
--- a/XMLReader.m
+++ b/XMLReader.m
@@ -7,7 +7,7 @@
 
 #import "XMLReader.h"
 
-NSString *const kXMLReaderTextNodeKey		= @"@text";
+NSString *const kXMLReaderTextNodeKey = @"#text";
 
 @interface XMLReader ()
 

--- a/XMLReader.m
+++ b/XMLReader.m
@@ -7,8 +7,7 @@
 
 #import "XMLReader.h"
 
-NSString *const kXMLReaderTextNodeKey		= @"text";
-NSString *const kXMLReaderAttributePrefix	= @"@";
+NSString *const kXMLReaderTextNodeKey		= @"@text";
 
 @interface XMLReader ()
 


### PR DESCRIPTION
If I have an XML like this:

< forecast code="1" text="Sunny">My Text Body< / forecast>

The current resulting NSDictionary is this:

{ "forecast" = { "code" = "1", "text" = "My Text Body"} }

The "text" attribute value is lost because you are using "text" for the tag body.

I changed that to be "#text", so that will not conflict anymore. Then the result dictionary will be:

{ "forecast" = { "code" = "1", "text" = "Sunny", "#text" = "My Text Body"} }

Note: This change can break somebody else's code if he does not update it's code.
